### PR TITLE
Project name parameter as alternative to compose file on down

### DIFF
--- a/pkg/amazon/down.go
+++ b/pkg/amazon/down.go
@@ -5,18 +5,17 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/cloudformation"
 	cf "github.com/aws/aws-sdk-go/service/cloudformation"
-	"github.com/docker/ecs-plugin/pkg/compose"
 )
 
-func (c *client) ComposeDown(project *compose.Project, keepLoadBalancer, deleteCluster bool) error {
+func (c *client) ComposeDown(projectName *string, keepLoadBalancer, deleteCluster bool) error {
 	_, err := c.CF.DeleteStack(&cloudformation.DeleteStackInput{
-		StackName: &project.Name,
+		StackName: projectName,
 	})
 	if err != nil {
 		return err
 	}
 	fmt.Printf("Delete stack ")
-	if err = c.CF.WaitUntilStackDeleteComplete(&cf.DescribeStacksInput{StackName: &project.Name}); err != nil {
+	if err = c.CF.WaitUntilStackDeleteComplete(&cf.DescribeStacksInput{StackName: projectName}); err != nil {
 		return err
 	}
 	fmt.Printf("... done.\n")

--- a/pkg/compose/api.go
+++ b/pkg/compose/api.go
@@ -5,5 +5,5 @@ import "github.com/awslabs/goformation/v4/cloudformation"
 type API interface {
 	Convert(project *Project, loadBalancerArn *string) (*cloudformation.Template, error)
 	ComposeUp(project *Project, loadBalancerArn *string) error
-	ComposeDown(project *Project, keepLoadBalancer, deleteCluster bool) error
+	ComposeDown(projectName *string, keepLoadBalancer, deleteCluster bool) error
 }

--- a/pkg/compose/opts.go
+++ b/pkg/compose/opts.go
@@ -20,7 +20,7 @@ type ProjectFunc func(project *Project, args []string) error
 // WithProject wrap a ProjectFunc into a cobra command
 func WithProject(options *ProjectOptions, f ProjectFunc) func(cmd *cobra.Command, args []string) error {
 	return func(cmd *cobra.Command, args []string) error {
-		project, err := projectFromOptions(options)
+		project, err := ProjectFromOptions(options)
 		if err != nil {
 			return err
 		}

--- a/pkg/compose/project.go
+++ b/pkg/compose/project.go
@@ -34,7 +34,7 @@ func NewProject(config types.ConfigDetails, name string) (*Project, error) {
 }
 
 // projectFromOptions load a compose project based on command line options
-func projectFromOptions(options *ProjectOptions) (*Project, error) {
+func ProjectFromOptions(options *ProjectOptions) (*Project, error) {
 	configPath, err := getConfigPathFromOptions(options)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: aiordache <anca.iordache@docker.com>

Add project name parameter to the down command as alternative to passing a compose file.

```
$ docker ecs --profile sandbox.devtools.developer --cluster nxcluster --region eu-west-3 compose -f nginx/docker-compose.yml up
nginx CREATE_IN_PROGRESS
```
To uninstall we can do
```
$ docker ecs --profile sandbox.devtools.developer --region eu-west-3 compose -f nginx/docker-compose.yml down
Delete stack ... done.
```
or
```
$ cd nginx 
$ docker ecs --profile sandbox.devtools.developer --region eu-west-3 compose down
Delete stack ... done.
```
or
```
$ docker ecs --profile sandbox.devtools.developer --region eu-west-3 compose down nginx
Delete stack ... done.
```

closes https://github.com/docker/ecs-plugin/issues/21