### PR TITLE
Implement "network" using SecurityGroups

### DIFF
--- a/pkg/amazon/client.go
+++ b/pkg/amazon/client.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	ProjectTag = "com.docker.compose.project"
+	NetworkTag = "com.docker.compose.network"
 )
 
 func NewClient(profile string, cluster string, region string) (compose.API, error) {

--- a/pkg/amazon/validate.go
+++ b/pkg/amazon/validate.go
@@ -15,6 +15,15 @@ func (c *client) Validate(project *compose.Project) error {
 		}
 	}
 
+	for i, service := range project.Services {
+		if len(service.Networks) == 0 {
+			// Service without explicit network attachment are implicitly exposed on default network
+			// FIXME move this to compose-go
+			service.Networks = map[string]*types.ServiceNetworkConfig{"default": nil}
+			project.Services[i] = service
+		}
+	}
+
 	// Here we can check for incompatible attributes, inject sane defaults, etc
 	return nil
 }


### PR DESCRIPTION
**What I did**
Create a SecurityGroup per compose network
SecurityGroup allow to define permissions for attached services to communicate together, and as such allow to reproduce the intent of compose's "networks" whenever AWS has no direct equivalent.

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/81067776-80531080-8edf-11ea-9c36-3a6d4d805cdb.png)
