### PR TITLE
Make cluster optional in context setup

### DIFF
--- a/cmd/commands/setup.go
+++ b/cmd/commands/setup.go
@@ -30,10 +30,6 @@ func (s setupOptions) unsetRequiredArgs() []string {
 	if s.context.Profile == "" {
 		unset = append(unset, "profile")
 	}
-	if s.context.Cluster == "" {
-		unset = append(unset, "cluster")
-	}
-
 	if s.context.Region == "" {
 		unset = append(unset, "region")
 	}
@@ -204,7 +200,7 @@ func setRegion(opts *setupOptions, section ini.Section) error {
 }
 
 func setCluster(opts *setupOptions, err error) error {
-	result, err := promptString(opts.context.Cluster, "cluster name", enterLabelPrefix, 2)
+	result, err := promptString(opts.context.Cluster, "cluster name", enterLabelPrefix, 0)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

**What I did**
Make `cluster` flag optional in `setup` command

**Related issue**
Needed for #53 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/81579716-c52dea00-93ac-11ea-853a-11f497afacb8.png)
