### PR TITLE
Add security group declaration in cloudformation conversion tests

### DIFF
--- a/pkg/amazon/testdata/simple/simple-cloudformation-conversion.golden
+++ b/pkg/amazon/testdata/simple/simple-cloudformation-conversion.golden
@@ -58,6 +58,26 @@
       },
       "Type": "AWS::Logs::LogGroup"
     },
+    "TestSimpleConvertDefaultNetwork": {
+      "Properties": {
+        "GroupDescription": "TestSimpleConvert default Security Group",
+        "GroupName": "TestSimpleConvertDefaultNetwork",
+        "Tags": [
+          {
+            "Key": "com.docker.compose.project",
+            "Value": "TestSimpleConvert"
+          },
+          {
+            "Key": "com.docker.compose.network",
+            "Value": "default"
+          }
+        ],
+        "VpcId": {
+          "Ref": "ParameterVPCId"
+        }
+      },
+      "Type": "AWS::EC2::SecurityGroup"
+    },
     "simpleService": {
       "Properties": {
         "Cluster": {
@@ -76,6 +96,11 @@
         "NetworkConfiguration": {
           "AwsvpcConfiguration": {
             "AssignPublicIp": "ENABLED",
+            "SecurityGroups": [
+              {
+                "Ref": "TestSimpleConvertDefaultNetwork"
+              }
+            ],
             "Subnets": [
               {
                 "Ref": "ParameterSubnet1Id"

--- a/pkg/amazon/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
+++ b/pkg/amazon/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
@@ -58,6 +58,26 @@
       },
       "Type": "AWS::Logs::LogGroup"
     },
+    "TestSimpleWithOverridesDefaultNetwork": {
+      "Properties": {
+        "GroupDescription": "TestSimpleWithOverrides default Security Group",
+        "GroupName": "TestSimpleWithOverridesDefaultNetwork",
+        "Tags": [
+          {
+            "Key": "com.docker.compose.project",
+            "Value": "TestSimpleWithOverrides"
+          },
+          {
+            "Key": "com.docker.compose.network",
+            "Value": "default"
+          }
+        ],
+        "VpcId": {
+          "Ref": "ParameterVPCId"
+        }
+      },
+      "Type": "AWS::EC2::SecurityGroup"
+    },
     "simpleService": {
       "Properties": {
         "Cluster": {
@@ -76,6 +96,11 @@
         "NetworkConfiguration": {
           "AwsvpcConfiguration": {
             "AssignPublicIp": "ENABLED",
+            "SecurityGroups": [
+              {
+                "Ref": "TestSimpleWithOverridesDefaultNetwork"
+              }
+            ],
             "Subnets": [
               {
                 "Ref": "ParameterSubnet1Id"


### PR DESCRIPTION
Signed-off-by: Guillaume Lours <guillaume.lours@docker.com>

**What I did**
Fix broken cloudformation convertion tests

**Related issue**
N/A

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/705411/82198067-12094780-98fc-11ea-9188-7ed825c3791d.png)
