### PR TITLE
Support pull from ECR

### DIFF
--- a/pkg/amazon/cloudformation.go
+++ b/pkg/amazon/cloudformation.go
@@ -120,6 +120,7 @@ func (c client) Convert(project *compose.Project) (*cloudformation.Template, err
 			Policies:                 rolePolicies,
 			ManagedPolicyArns: []string{
 				ECSTaskExecutionPolicy,
+				ECRReadOnlyPolicy,
 			},
 		}
 		template.Resources[taskDefinition] = definition

--- a/pkg/amazon/iam.go
+++ b/pkg/amazon/iam.go
@@ -2,6 +2,7 @@ package amazon
 
 const (
 	ECSTaskExecutionPolicy = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+	ECRReadOnlyPolicy      = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 
 	ActionGetSecretValue = "secretsmanager:GetSecretValue"
 	ActionGetParameters  = "ssm:GetParameters"

--- a/pkg/amazon/testdata/simple/simple-cloudformation-conversion.golden
+++ b/pkg/amazon/testdata/simple/simple-cloudformation-conversion.golden
@@ -217,7 +217,8 @@
           "Version": "2012-10-17"
         },
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+          "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+          "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
         ]
       },
       "Type": "AWS::IAM::Role"

--- a/pkg/amazon/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
+++ b/pkg/amazon/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
@@ -217,7 +217,8 @@
           "Version": "2012-10-17"
         },
         "ManagedPolicyArns": [
-          "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+          "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+          "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
         ]
       },
       "Type": "AWS::IAM::Role"


### PR DESCRIPTION
**What I did**
Run services with `AmazonEC2ContainerRegistryReadOnly` managed policy so they can pull from ECR (same aws account)

**Related issue**
closes #58

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/82823603-2a530680-9ea8-11ea-8bbf-cf75d3fb1968.png)
