### PR TITLE
Configure networks with internal communication enabled

### DIFF
--- a/pkg/amazon/client.go
+++ b/pkg/amazon/client.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	ProjectTag = "com.docker.compose.project"
+	ServiceTag = "com.docker.compose.service"
 	NetworkTag = "com.docker.compose.network"
 )
 

--- a/pkg/amazon/convert.go
+++ b/pkg/amazon/convert.go
@@ -57,7 +57,7 @@ func Convert(project *compose.Project, service types.ServiceConfig) (*ecs.TaskDe
 					Options: map[string]string{
 						"awslogs-region":        cloudformation.Ref("AWS::Region"),
 						"awslogs-group":         cloudformation.Ref("LogGroup"),
-						"awslogs-stream-prefix": service.Name,
+						"awslogs-stream-prefix": project.Name,
 					},
 				},
 				Name:                   service.Name,

--- a/pkg/amazon/testdata/simple/simple-cloudformation-conversion.golden
+++ b/pkg/amazon/testdata/simple/simple-cloudformation-conversion.golden
@@ -58,27 +58,7 @@
       },
       "Type": "AWS::Logs::LogGroup"
     },
-    "TestSimpleConvertDefaultNetwork": {
-      "Properties": {
-        "GroupDescription": "TestSimpleConvert default Security Group",
-        "GroupName": "TestSimpleConvertDefaultNetwork",
-        "Tags": [
-          {
-            "Key": "com.docker.compose.project",
-            "Value": "TestSimpleConvert"
-          },
-          {
-            "Key": "com.docker.compose.network",
-            "Value": "default"
-          }
-        ],
-        "VpcId": {
-          "Ref": "ParameterVPCId"
-        }
-      },
-      "Type": "AWS::EC2::SecurityGroup"
-    },
-    "simpleService": {
+    "SimpleService": {
       "Properties": {
         "Cluster": {
           "Fn::If": [
@@ -117,19 +97,29 @@
           {
             "RegistryArn": {
               "Fn::GetAtt": [
-                "simpleServiceDiscoveryEntry",
+                "SimpleServiceDiscoveryEntry",
                 "Arn"
               ]
             }
           }
         ],
+        "Tags": [
+          {
+            "Key": "com.docker.compose.project",
+            "Value": "TestSimpleConvert"
+          },
+          {
+            "Key": "com.docker.compose.service",
+            "Value": "simple"
+          }
+        ],
         "TaskDefinition": {
-          "Ref": "simpleTaskDefinition"
+          "Ref": "SimpleTaskDefinition"
         }
       },
       "Type": "AWS::ECS::Service"
     },
-    "simpleServiceDiscoveryEntry": {
+    "SimpleServiceDiscoveryEntry": {
       "Properties": {
         "Description": "\"simple\" service discovery entry in Cloud Map",
         "DnsConfig": {
@@ -148,7 +138,7 @@
       },
       "Type": "AWS::ServiceDiscovery::Service"
     },
-    "simpleTaskDefinition": {
+    "SimpleTaskDefinition": {
       "Properties": {
         "ContainerDefinitions": [
           {
@@ -181,7 +171,7 @@
                 "awslogs-region": {
                   "Ref": "AWS::Region"
                 },
-                "awslogs-stream-prefix": "simple"
+                "awslogs-stream-prefix": "TestSimpleConvert"
               }
             },
             "Name": "simple"
@@ -189,7 +179,7 @@
         ],
         "Cpu": "256",
         "ExecutionRoleArn": {
-          "Ref": "simpleTaskExecutionRole"
+          "Ref": "SimpleTaskExecutionRole"
         },
         "Family": "TestSimpleConvert-simple",
         "Memory": "512",
@@ -200,7 +190,7 @@
       },
       "Type": "AWS::ECS::TaskDefinition"
     },
-    "simpleTaskExecutionRole": {
+    "SimpleTaskExecutionRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -222,6 +212,37 @@
         ]
       },
       "Type": "AWS::IAM::Role"
+    },
+    "TestSimpleConvertDefaultNetwork": {
+      "Properties": {
+        "GroupDescription": "TestSimpleConvert default Security Group",
+        "GroupName": "TestSimpleConvertDefaultNetwork",
+        "Tags": [
+          {
+            "Key": "com.docker.compose.project",
+            "Value": "TestSimpleConvert"
+          },
+          {
+            "Key": "com.docker.compose.network",
+            "Value": "default"
+          }
+        ],
+        "VpcId": {
+          "Ref": "ParameterVPCId"
+        }
+      },
+      "Type": "AWS::EC2::SecurityGroup"
+    },
+    "TestSimpleConvertDefaultNetworkIngress": {
+      "Properties": {
+        "CidrIp": "0.0.0.0/0",
+        "Description": "Allow communication within network default",
+        "GroupId": {
+          "Ref": "TestSimpleConvertDefaultNetwork"
+        },
+        "IpProtocol": "-1"
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
     }
   }
 }

--- a/pkg/amazon/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
+++ b/pkg/amazon/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
@@ -58,27 +58,7 @@
       },
       "Type": "AWS::Logs::LogGroup"
     },
-    "TestSimpleWithOverridesDefaultNetwork": {
-      "Properties": {
-        "GroupDescription": "TestSimpleWithOverrides default Security Group",
-        "GroupName": "TestSimpleWithOverridesDefaultNetwork",
-        "Tags": [
-          {
-            "Key": "com.docker.compose.project",
-            "Value": "TestSimpleWithOverrides"
-          },
-          {
-            "Key": "com.docker.compose.network",
-            "Value": "default"
-          }
-        ],
-        "VpcId": {
-          "Ref": "ParameterVPCId"
-        }
-      },
-      "Type": "AWS::EC2::SecurityGroup"
-    },
-    "simpleService": {
+    "SimpleService": {
       "Properties": {
         "Cluster": {
           "Fn::If": [
@@ -117,19 +97,29 @@
           {
             "RegistryArn": {
               "Fn::GetAtt": [
-                "simpleServiceDiscoveryEntry",
+                "SimpleServiceDiscoveryEntry",
                 "Arn"
               ]
             }
           }
         ],
+        "Tags": [
+          {
+            "Key": "com.docker.compose.project",
+            "Value": "TestSimpleWithOverrides"
+          },
+          {
+            "Key": "com.docker.compose.service",
+            "Value": "simple"
+          }
+        ],
         "TaskDefinition": {
-          "Ref": "simpleTaskDefinition"
+          "Ref": "SimpleTaskDefinition"
         }
       },
       "Type": "AWS::ECS::Service"
     },
-    "simpleServiceDiscoveryEntry": {
+    "SimpleServiceDiscoveryEntry": {
       "Properties": {
         "Description": "\"simple\" service discovery entry in Cloud Map",
         "DnsConfig": {
@@ -148,7 +138,7 @@
       },
       "Type": "AWS::ServiceDiscovery::Service"
     },
-    "simpleTaskDefinition": {
+    "SimpleTaskDefinition": {
       "Properties": {
         "ContainerDefinitions": [
           {
@@ -181,7 +171,7 @@
                 "awslogs-region": {
                   "Ref": "AWS::Region"
                 },
-                "awslogs-stream-prefix": "simple"
+                "awslogs-stream-prefix": "TestSimpleWithOverrides"
               }
             },
             "Name": "simple"
@@ -189,7 +179,7 @@
         ],
         "Cpu": "256",
         "ExecutionRoleArn": {
-          "Ref": "simpleTaskExecutionRole"
+          "Ref": "SimpleTaskExecutionRole"
         },
         "Family": "TestSimpleWithOverrides-simple",
         "Memory": "512",
@@ -200,7 +190,7 @@
       },
       "Type": "AWS::ECS::TaskDefinition"
     },
-    "simpleTaskExecutionRole": {
+    "SimpleTaskExecutionRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -222,6 +212,37 @@
         ]
       },
       "Type": "AWS::IAM::Role"
+    },
+    "TestSimpleWithOverridesDefaultNetwork": {
+      "Properties": {
+        "GroupDescription": "TestSimpleWithOverrides default Security Group",
+        "GroupName": "TestSimpleWithOverridesDefaultNetwork",
+        "Tags": [
+          {
+            "Key": "com.docker.compose.project",
+            "Value": "TestSimpleWithOverrides"
+          },
+          {
+            "Key": "com.docker.compose.network",
+            "Value": "default"
+          }
+        ],
+        "VpcId": {
+          "Ref": "ParameterVPCId"
+        }
+      },
+      "Type": "AWS::EC2::SecurityGroup"
+    },
+    "TestSimpleWithOverridesDefaultNetworkIngress": {
+      "Properties": {
+        "CidrIp": "0.0.0.0/0",
+        "Description": "Allow communication within network default",
+        "GroupId": {
+          "Ref": "TestSimpleWithOverridesDefaultNetwork"
+        },
+        "IpProtocol": "-1"
+      },
+      "Type": "AWS::EC2::SecurityGroupIngress"
     }
   }
 }

--- a/pkg/compose/normalize.go
+++ b/pkg/compose/normalize.go
@@ -49,5 +49,33 @@ func Normalize(model *types.Config) error {
 		}
 		model.Services[i] = s
 	}
+
+	for i, n := range model.Networks {
+		if n.Name == "" {
+			n.Name = i
+			model.Networks[i] = n
+		}
+	}
+
+	for i, v := range model.Volumes {
+		if v.Name == "" {
+			v.Name = i
+			model.Volumes[i] = v
+		}
+	}
+
+	for i, c := range model.Configs {
+		if c.Name == "" {
+			c.Name = i
+			model.Configs[i] = c
+		}
+	}
+
+	for i, s := range model.Secrets {
+		if s.Name == "" {
+			s.Name = i
+			model.Secrets[i] = s
+		}
+	}
 	return nil
 }

--- a/pkg/console/colors.go
+++ b/pkg/console/colors.go
@@ -1,0 +1,58 @@
+package console
+
+import (
+	"strconv"
+)
+
+var NAMES = []string{
+	"grey",
+	"red",
+	"green",
+	"yellow",
+	"blue",
+	"magenta",
+	"cyan",
+	"white",
+}
+
+var COLORS map[string]ColorFunc
+
+// ColorFunc use ANSI codes to render colored text on console
+type ColorFunc func(s string) string
+
+func makeColorFunc(code string) ColorFunc {
+	return func(s string) string {
+		return ansiColor(code, s)
+	}
+}
+
+var Rainbow = make(chan ColorFunc)
+
+func init() {
+	COLORS = map[string]ColorFunc{}
+	for i, name := range NAMES {
+		COLORS[name] = makeColorFunc(strconv.Itoa(30 + i))
+		COLORS["intense_"+name] = makeColorFunc(strconv.Itoa(30+i) + ";1")
+	}
+
+	go func() {
+		i := 0
+		rainbow := []ColorFunc{
+			COLORS["cyan"],
+			COLORS["yellow"],
+			COLORS["green"],
+			COLORS["magenta"],
+			COLORS["blue"],
+			COLORS["intense_cyan"],
+			COLORS["intense_yellow"],
+			COLORS["intense_green"],
+			COLORS["intense_magenta"],
+			COLORS["intense_blue"],
+		}
+
+		for {
+			Rainbow <- rainbow[i]
+			i = (i + 1) % len(rainbow)
+		}
+	}()
+}


### PR DESCRIPTION
**What I did**
networks (i.e. securitygroups) get created with an ingress rule to allow services within a common network to communicate without need for explicit port exposure.


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/82888453-9d608980-9f49-11ea-9dd4-488d772f4d5b.png)
