### PR TITLE
Create the plugin directory if it doesn't exist.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ e2e: build ## Run tests
 	go test ./... -v -tags=e2e
 
 dev: build
+	@mkdir -p ~/.docker/cli-plugins/
 	ln -f -s "${PWD}/dist/docker-ecs" "${HOME}/.docker/cli-plugins/docker-ecs"
 
 lint: ## Verify Go files


### PR DESCRIPTION
**What I did**

I ran `make dev` it failed because I didn't have a Docker plugin directory in my home. A lot of non Docker developers probably would hit the same issue. So I just tossed a quick mkdir into the makefile.

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![cute](https://blazepress.com/.image/c_limit%2Ccs_srgb%2Cq_auto:good%2Cw_605/MTI5NTUyOTAyMDExMzUxMDEw/tiny-baby-animals-5jpg.webp)