### PR TITLE
Register services with a known port with SRV record

### DIFF
--- a/pkg/amazon/testdata/simple/simple-cloudformation-conversion.golden
+++ b/pkg/amazon/testdata/simple/simple-cloudformation-conversion.golden
@@ -135,7 +135,7 @@
         "DnsConfig": {
           "DnsRecords": [
             {
-              "TTL": 300,
+              "TTL": 60,
               "Type": "A"
             }
           ],

--- a/pkg/amazon/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
+++ b/pkg/amazon/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
@@ -135,7 +135,7 @@
         "DnsConfig": {
           "DnsRecords": [
             {
-              "TTL": 300,
+              "TTL": 60,
               "Type": "A"
             }
           ],


### PR DESCRIPTION
**What I did**
Services are registered on CloudMap DNS with a SRV record
this require us to know service port, so is limited to compose services with an explicit port

**Related issue**
https://github.com/docker/docker_aws/issues/15#issuecomment-634357859

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/83019691-a7f15080-a027-11ea-8bc3-d04a3431191c.png)
