### PR TITLE
Compute resource names to avoid unsupported characters

### DIFF
--- a/pkg/amazon/convert.go
+++ b/pkg/amazon/convert.go
@@ -57,7 +57,7 @@ func Convert(project *compose.Project, service types.ServiceConfig) (*ecs.TaskDe
 					Options: map[string]string{
 						"awslogs-region":        cloudformation.Ref("AWS::Region"),
 						"awslogs-group":         cloudformation.Ref("LogGroup"),
-						"awslogs-stream-prefix": service.Name,
+						"awslogs-stream-prefix": project.Name,
 					},
 				},
 				Name:                   service.Name,

--- a/pkg/amazon/testdata/simple/simple-cloudformation-conversion.golden
+++ b/pkg/amazon/testdata/simple/simple-cloudformation-conversion.golden
@@ -58,27 +58,7 @@
       },
       "Type": "AWS::Logs::LogGroup"
     },
-    "TestSimpleConvertDefaultNetwork": {
-      "Properties": {
-        "GroupDescription": "TestSimpleConvert default Security Group",
-        "GroupName": "TestSimpleConvertDefaultNetwork",
-        "Tags": [
-          {
-            "Key": "com.docker.compose.project",
-            "Value": "TestSimpleConvert"
-          },
-          {
-            "Key": "com.docker.compose.network",
-            "Value": "default"
-          }
-        ],
-        "VpcId": {
-          "Ref": "ParameterVPCId"
-        }
-      },
-      "Type": "AWS::EC2::SecurityGroup"
-    },
-    "simpleService": {
+    "SimpleService": {
       "Properties": {
         "Cluster": {
           "Fn::If": [
@@ -117,7 +97,7 @@
           {
             "RegistryArn": {
               "Fn::GetAtt": [
-                "simpleServiceDiscoveryEntry",
+                "SimpleServiceDiscoveryEntry",
                 "Arn"
               ]
             }
@@ -134,12 +114,12 @@
           }
         ],
         "TaskDefinition": {
-          "Ref": "simpleTaskDefinition"
+          "Ref": "SimpleTaskDefinition"
         }
       },
       "Type": "AWS::ECS::Service"
     },
-    "simpleServiceDiscoveryEntry": {
+    "SimpleServiceDiscoveryEntry": {
       "Properties": {
         "Description": "\"simple\" service discovery entry in Cloud Map",
         "DnsConfig": {
@@ -158,7 +138,7 @@
       },
       "Type": "AWS::ServiceDiscovery::Service"
     },
-    "simpleTaskDefinition": {
+    "SimpleTaskDefinition": {
       "Properties": {
         "ContainerDefinitions": [
           {
@@ -191,7 +171,7 @@
                 "awslogs-region": {
                   "Ref": "AWS::Region"
                 },
-                "awslogs-stream-prefix": "simple"
+                "awslogs-stream-prefix": "TestSimpleConvert"
               }
             },
             "Name": "simple"
@@ -199,7 +179,7 @@
         ],
         "Cpu": "256",
         "ExecutionRoleArn": {
-          "Ref": "simpleTaskExecutionRole"
+          "Ref": "SimpleTaskExecutionRole"
         },
         "Family": "TestSimpleConvert-simple",
         "Memory": "512",
@@ -210,7 +190,7 @@
       },
       "Type": "AWS::ECS::TaskDefinition"
     },
-    "simpleTaskExecutionRole": {
+    "SimpleTaskExecutionRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -232,6 +212,26 @@
         ]
       },
       "Type": "AWS::IAM::Role"
+    },
+    "TestSimpleConvertDefaultNetwork": {
+      "Properties": {
+        "GroupDescription": "TestSimpleConvert default Security Group",
+        "GroupName": "TestSimpleConvertDefaultNetwork",
+        "Tags": [
+          {
+            "Key": "com.docker.compose.project",
+            "Value": "TestSimpleConvert"
+          },
+          {
+            "Key": "com.docker.compose.network",
+            "Value": "default"
+          }
+        ],
+        "VpcId": {
+          "Ref": "ParameterVPCId"
+        }
+      },
+      "Type": "AWS::EC2::SecurityGroup"
     }
   }
 }

--- a/pkg/amazon/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
+++ b/pkg/amazon/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
@@ -58,27 +58,7 @@
       },
       "Type": "AWS::Logs::LogGroup"
     },
-    "TestSimpleWithOverridesDefaultNetwork": {
-      "Properties": {
-        "GroupDescription": "TestSimpleWithOverrides default Security Group",
-        "GroupName": "TestSimpleWithOverridesDefaultNetwork",
-        "Tags": [
-          {
-            "Key": "com.docker.compose.project",
-            "Value": "TestSimpleWithOverrides"
-          },
-          {
-            "Key": "com.docker.compose.network",
-            "Value": "default"
-          }
-        ],
-        "VpcId": {
-          "Ref": "ParameterVPCId"
-        }
-      },
-      "Type": "AWS::EC2::SecurityGroup"
-    },
-    "simpleService": {
+    "SimpleService": {
       "Properties": {
         "Cluster": {
           "Fn::If": [
@@ -117,7 +97,7 @@
           {
             "RegistryArn": {
               "Fn::GetAtt": [
-                "simpleServiceDiscoveryEntry",
+                "SimpleServiceDiscoveryEntry",
                 "Arn"
               ]
             }
@@ -134,12 +114,12 @@
           }
         ],
         "TaskDefinition": {
-          "Ref": "simpleTaskDefinition"
+          "Ref": "SimpleTaskDefinition"
         }
       },
       "Type": "AWS::ECS::Service"
     },
-    "simpleServiceDiscoveryEntry": {
+    "SimpleServiceDiscoveryEntry": {
       "Properties": {
         "Description": "\"simple\" service discovery entry in Cloud Map",
         "DnsConfig": {
@@ -158,7 +138,7 @@
       },
       "Type": "AWS::ServiceDiscovery::Service"
     },
-    "simpleTaskDefinition": {
+    "SimpleTaskDefinition": {
       "Properties": {
         "ContainerDefinitions": [
           {
@@ -191,7 +171,7 @@
                 "awslogs-region": {
                   "Ref": "AWS::Region"
                 },
-                "awslogs-stream-prefix": "simple"
+                "awslogs-stream-prefix": "TestSimpleWithOverrides"
               }
             },
             "Name": "simple"
@@ -199,7 +179,7 @@
         ],
         "Cpu": "256",
         "ExecutionRoleArn": {
-          "Ref": "simpleTaskExecutionRole"
+          "Ref": "SimpleTaskExecutionRole"
         },
         "Family": "TestSimpleWithOverrides-simple",
         "Memory": "512",
@@ -210,7 +190,7 @@
       },
       "Type": "AWS::ECS::TaskDefinition"
     },
-    "simpleTaskExecutionRole": {
+    "SimpleTaskExecutionRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [
@@ -232,6 +212,26 @@
         ]
       },
       "Type": "AWS::IAM::Role"
+    },
+    "TestSimpleWithOverridesDefaultNetwork": {
+      "Properties": {
+        "GroupDescription": "TestSimpleWithOverrides default Security Group",
+        "GroupName": "TestSimpleWithOverridesDefaultNetwork",
+        "Tags": [
+          {
+            "Key": "com.docker.compose.project",
+            "Value": "TestSimpleWithOverrides"
+          },
+          {
+            "Key": "com.docker.compose.network",
+            "Value": "default"
+          }
+        ],
+        "VpcId": {
+          "Ref": "ParameterVPCId"
+        }
+      },
+      "Type": "AWS::EC2::SecurityGroup"
     }
   }
 }


### PR DESCRIPTION
**What I did**
Remove unsupported characters when building CloudFormation resource names to enforce alphanumeric IDs

**Related issue**
closes #76

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/83037743-72a32d80-a03c-11ea-99a4-1d550cbce044.png)
