### PR TITLE
Use distinct family per service definition

### DIFF
--- a/pkg/amazon/convert.go
+++ b/pkg/amazon/convert.go
@@ -77,7 +77,7 @@ func Convert(project *compose.Project, service types.ServiceConfig) (*ecs.TaskDe
 			},
 		},
 		Cpu:                     cpu,
-		Family:                  project.Name,
+		Family:                  fmt.Sprintf("%s-%s", project.Name, service.Name),
 		IpcMode:                 service.Ipc,
 		Memory:                  mem,
 		NetworkMode:             ecsapi.NetworkModeAwsvpc, // FIXME could be set by service.NetworkMode, Fargate only supports network mode ‘awsvpc’.

--- a/pkg/amazon/list.go
+++ b/pkg/amazon/list.go
@@ -20,9 +20,13 @@ func (c *client) ComposePs(ctx context.Context, project *compose.Project) error 
 	fmt.Fprintf(w, "Name\tState\tPorts\n")
 	defer w.Flush()
 
-	arns, err := c.api.ListTasks(ctx, cluster, project.Name)
-	if err != nil {
-		return err
+	arns := []string{}
+	for _, service := range project.Services {
+		tasks, err := c.api.ListTasks(ctx, cluster, service.Name)
+		if err != nil {
+			return err
+		}
+		arns = append(arns, tasks...)
 	}
 	if len(arns) == 0 {
 		return nil

--- a/pkg/amazon/sdk.go
+++ b/pkg/amazon/sdk.go
@@ -341,10 +341,10 @@ func (s sdk) GetLogs(ctx context.Context, name string, consumer LogConsumer) err
 	}
 }
 
-func (s sdk) ListTasks(ctx context.Context, cluster string, name string) ([]string, error) {
+func (s sdk) ListTasks(ctx context.Context, cluster string, service string) ([]string, error) {
 	tasks, err := s.ECS.ListTasksWithContext(ctx, &ecs.ListTasksInput{
-		Cluster: aws.String(cluster),
-		Family:  aws.String(name),
+		Cluster:     aws.String(cluster),
+		ServiceName: aws.String(service),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/amazon/testdata/simple/simple-cloudformation-conversion.golden
+++ b/pkg/amazon/testdata/simple/simple-cloudformation-conversion.golden
@@ -181,7 +181,7 @@
         "ExecutionRoleArn": {
           "Ref": "SimpleTaskExecutionRole"
         },
-        "Family": "TestSimpleConvert",
+        "Family": "TestSimpleConvert-simple",
         "Memory": "512",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [

--- a/pkg/amazon/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
+++ b/pkg/amazon/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
@@ -181,7 +181,7 @@
         "ExecutionRoleArn": {
           "Ref": "SimpleTaskExecutionRole"
         },
-        "Family": "TestSimpleWithOverrides",
+        "Family": "TestSimpleWithOverrides-simple",
         "Memory": "512",
         "NetworkMode": "awsvpc",
         "RequiresCompatibilities": [


### PR DESCRIPTION
**What I did**
Use a distinct family name per service, as recommended by AWS docs

**Related issue**
closes #91

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/83520938-c56a6280-a4de-11ea-945e-bd55a534bf36.png)
