### PR TITLE
custom extension to select existing VPC and SecurityGroups

### DIFF
--- a/pkg/amazon/convert.go
+++ b/pkg/amazon/convert.go
@@ -318,7 +318,7 @@ func getImage(image string) string {
 func getRepoCredentials(service types.ServiceConfig) *ecs.TaskDefinition_RepositoryCredentials {
 	// extract registry and namespace string from image name
 	for key, value := range service.Extras {
-		if key == "x-aws-pull_credentials" {
+		if key == ExtensionPullCredentials {
 			return &ecs.TaskDefinition_RepositoryCredentials{CredentialsParameter: value.(string)}
 		}
 	}

--- a/pkg/amazon/testdata/simple/simple-cloudformation-conversion.golden
+++ b/pkg/amazon/testdata/simple/simple-cloudformation-conversion.golden
@@ -16,11 +16,11 @@
       "Type": "String"
     },
     "ParameterSubnet1Id": {
-      "Description": "SubnetId,for Availability Zone 1 in the region in your VPC",
+      "Description": "SubnetId, for Availability Zone 1 in the region in your VPC",
       "Type": "AWS::EC2::Subnet::Id"
     },
     "ParameterSubnet2Id": {
-      "Description": "SubnetId,for Availability Zone 1 in the region in your VPC",
+      "Description": "SubnetId, for Availability Zone 2 in the region in your VPC",
       "Type": "AWS::EC2::Subnet::Id"
     },
     "ParameterVPCId": {

--- a/pkg/amazon/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
+++ b/pkg/amazon/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
@@ -16,11 +16,11 @@
       "Type": "String"
     },
     "ParameterSubnet1Id": {
-      "Description": "SubnetId,for Availability Zone 1 in the region in your VPC",
+      "Description": "SubnetId, for Availability Zone 1 in the region in your VPC",
       "Type": "AWS::EC2::Subnet::Id"
     },
     "ParameterSubnet2Id": {
-      "Description": "SubnetId,for Availability Zone 1 in the region in your VPC",
+      "Description": "SubnetId, for Availability Zone 2 in the region in your VPC",
       "Type": "AWS::EC2::Subnet::Id"
     },
     "ParameterVPCId": {

--- a/pkg/amazon/up.go
+++ b/pkg/amazon/up.go
@@ -59,18 +59,15 @@ func (c *client) ComposeUp(ctx context.Context, project *compose.Project) error 
 }
 
 func (c client) GetVPC(ctx context.Context, project *compose.Project) (string, error) {
-	//check compose file for the default external network
-	if net, ok := project.Networks["default"]; ok {
-		if net.External.External {
-			vpc := net.Name
-			ok, err := c.api.VpcExists(ctx, vpc)
-			if err != nil {
-				return "", err
-			}
-			if !ok {
-				return "", fmt.Errorf("VPC does not exist: %s", vpc)
-			}
-			return vpc, nil
+	//check compose file for custom VPC selected
+	if vpc, ok := project.Extras[ExtensionVPC]; ok {
+		vpcID := vpc.(string)
+		ok, err := c.api.VpcExists(ctx, vpcID)
+		if err != nil {
+			return "", err
+		}
+		if !ok {
+			return "", fmt.Errorf("VPC does not exist: %s", vpc)
 		}
 	}
 	defaultVPC, err := c.api.GetDefaultVPC(ctx)

--- a/pkg/amazon/x.go
+++ b/pkg/amazon/x.go
@@ -1,0 +1,7 @@
+package amazon
+
+const (
+	ExtensionSecurityGroup   = "x-aws-securitygroup"
+	ExtensionVPC             = "x-aws-vpc"
+	ExtensionPullCredentials = "x-aws-pull_credentials"
+)


### PR DESCRIPTION
**What I did**
Introduced x-aws-* custom extension so user can select an existing security group as "network" and deploy on an existing VPC

**Related issue**

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/83636957-1b0a4200-a5a7-11ea-9f34-c383672b6722.png)
