### PR TITLE
Test we create the expected policy document for pull_credentials

### DIFF
--- a/pkg/amazon/cloudformation.go
+++ b/pkg/amazon/cloudformation.go
@@ -426,7 +426,6 @@ func normalizeResourceName(s string) string {
 }
 
 func (c client) getPolicy(taskDef *ecs.TaskDefinition) (*PolicyDocument, error) {
-
 	arns := []string{}
 	for _, container := range taskDef.ContainerDefinitions {
 		if container.RepositoryCredentials != nil {

--- a/pkg/amazon/cloudformation_test.go
+++ b/pkg/amazon/cloudformation_test.go
@@ -4,15 +4,13 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/awslabs/goformation/v4/cloudformation/ec2"
-
 	"github.com/awslabs/goformation/v4/cloudformation"
+	"github.com/awslabs/goformation/v4/cloudformation/ec2"
+	"github.com/awslabs/goformation/v4/cloudformation/iam"
 	"github.com/compose-spec/compose-go/loader"
 	"github.com/compose-spec/compose-go/types"
-
-	"gotest.tools/assert"
-
 	"github.com/docker/ecs-plugin/pkg/compose"
+	"gotest.tools/assert"
 	"gotest.tools/v3/golden"
 )
 
@@ -28,6 +26,26 @@ func TestSimpleWithOverrides(t *testing.T) {
 	result := convertResultAsString(t, project, "TestCluster")
 	expected := "simple/simple-cloudformation-with-overrides-conversion.golden"
 	golden.Assert(t, result, expected)
+}
+
+func TestRolePolicy(t *testing.T) {
+	template := convertYaml(t, `
+version: "3"
+services:
+  foo:
+    image: hello_world
+    x-aws-pull_credentials: "secret"
+`)
+	role := template.Resources["FooTaskExecutionRole"].(*iam.Role)
+	assert.Check(t, role != nil)
+	assert.Check(t, role.ManagedPolicyArns[0] == ECSTaskExecutionPolicy)
+	assert.Check(t, role.ManagedPolicyArns[1] == ECRReadOnlyPolicy)
+	// We expect an extra policy has been created for x-aws-pull_credentials
+	assert.Check(t, len(role.Policies) == 1)
+	policy := role.Policies[0].PolicyDocument.(*PolicyDocument)
+	expected := []string{"secretsmanager:GetSecretValue", "ssm:GetParameters", "kms:Decrypt"}
+	assert.DeepEqual(t, expected, policy.Statement[0].Action)
+	assert.DeepEqual(t, []string{"secret"}, policy.Statement[0].Resource)
 }
 
 func TestMapNetworksToSecurityGroups(t *testing.T) {


### PR DESCRIPTION
**What I did**
A test case checking we produce the adequate IAM policy document to grant access to pull_credentials secret

**Related issue**
see #98 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/84014912-5af07100-a97b-11ea-8c18-91baf2478955.png)
