### PR TITLE
Customize SDK requests to AWS API with user-agent

### DIFF
--- a/builder.Makefile
+++ b/builder.Makefile
@@ -8,8 +8,8 @@ endif
 
 STATIC_FLAGS=CGO_ENABLED=0
 LDFLAGS := "-s -w \
-  -X github.com/docker/ecs-plugin/cmd/commands.GitCommit=$(COMMIT) \
-  -X github.com/docker/ecs-plugin/cmd/commands.Version=$(TAG)"
+  -X github.com/docker/ecs-plugin/internal.GitCommit=$(COMMIT) \
+  -X github.com/docker/ecs-plugin/internal.Version=$(TAG)"
 GO_BUILD=$(STATIC_FLAGS) go build -trimpath -ldflags=$(LDFLAGS)
 
 BINARY=dist/docker-ecs

--- a/cmd/commands/version.go
+++ b/cmd/commands/version.go
@@ -3,14 +3,9 @@ package commands
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
-)
+	"github.com/docker/ecs-plugin/internal"
 
-var (
-	// Version is the git tag that this was built from.
-	Version = "unknown"
-	// GitCommit is the commit that this was built from.
-	GitCommit = "unknown"
+	"github.com/spf13/cobra"
 )
 
 func VersionCommand() *cobra.Command {
@@ -18,7 +13,7 @@ func VersionCommand() *cobra.Command {
 		Use:   "version",
 		Short: "Show version.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintf(cmd.OutOrStdout(), "Docker ECS plugin %s (%s)\n", Version, GitCommit)
+			fmt.Fprintf(cmd.OutOrStdout(), "Docker ECS plugin %s (%s)\n", internal.Version, internal.GitCommit)
 			return nil
 		},
 	}

--- a/cmd/commands/version_test.go
+++ b/cmd/commands/version_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/ecs-plugin/internal"
+
 	"gotest.tools/v3/assert"
 )
 
@@ -14,5 +16,5 @@ func TestVersion(t *testing.T) {
 	root.SetOut(&out)
 	root.SetArgs([]string{"version"})
 	root.Execute()
-	assert.Check(t, strings.Contains(out.String(), Version))
+	assert.Check(t, strings.Contains(out.String(), internal.Version))
 }

--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/docker/ecs-plugin/cmd/commands"
+	"github.com/docker/ecs-plugin/internal"
 
 	"github.com/docker/cli/cli-plugins/manager"
 	"github.com/docker/cli/cli-plugins/plugin"
@@ -16,7 +17,7 @@ func main() {
 	}, manager.Metadata{
 		SchemaVersion: "0.1.0",
 		Vendor:        "Docker Inc.",
-		Version:       commands.Version,
+		Version:       internal.Version,
 		Experimental:  true,
 	})
 }

--- a/internal/version.go
+++ b/internal/version.go
@@ -1,0 +1,8 @@
+package internal
+
+var (
+	// Version is the git tag that this was built from.
+	Version = "unknown"
+	// GitCommit is the commit that this was built from.
+	GitCommit = "unknown"
+)

--- a/pkg/amazon/sdk/sdk.go
+++ b/pkg/amazon/sdk/sdk.go
@@ -6,6 +6,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/ecs-plugin/internal"
+
+	"github.com/aws/aws-sdk-go/aws/request"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
@@ -39,6 +43,9 @@ type sdk struct {
 }
 
 func NewAPI(sess *session.Session) API {
+	sess.Handlers.Build.PushBack(func(r *request.Request) {
+		request.AddToUserAgent(r, fmt.Sprintf("Docker CLI %s", internal.Version))
+	})
 	return sdk{
 		ECS: ecs.New(sess),
 		EC2: ec2.New(sess),


### PR DESCRIPTION
**What I did**
Configured AWS SDK so we include ecs-plugin version in HTTP User-Agent so Amazon can easily track requests made using Docker integration.

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/86374578-05129e80-bc85-11ea-9087-228bce6c125e.png)
