### PR TITLE
Unwrapp API errors to get user-friendly error message

### DIFF
--- a/cmd/commands/opts.go
+++ b/cmd/commands/opts.go
@@ -2,25 +2,10 @@ package commands
 
 import (
 	"github.com/compose-spec/compose-go/cli"
-	"github.com/compose-spec/compose-go/types"
-	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
 func AddFlags(o *cli.ProjectOptions, flags *pflag.FlagSet) {
 	flags.StringArrayVarP(&o.ConfigPaths, "file", "f", nil, "Specify an alternate compose file")
 	flags.StringVarP(&o.Name, "project-name", "n", "", "Specify an alternate project name (default: directory name)")
-}
-
-type ProjectFunc func(project *types.Project, args []string) error
-
-// WithProject wrap a ProjectFunc into a cobra command
-func WithProject(options *cli.ProjectOptions, f ProjectFunc) func(cmd *cobra.Command, args []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		project, err := cli.ProjectFromOptions(options)
-		if err != nil {
-			return err
-		}
-		return f(project, args)
-	}
 }

--- a/cmd/commands/secret.go
+++ b/cmd/commands/secret.go
@@ -47,11 +47,7 @@ func CreateSecret(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create NAME",
 		Short: "Creates a secret.",
-		RunE: docker.WithAwsContext(dockerCli, func(clusteropts docker.AwsContext, args []string) error {
-			backend, err := amazon.NewBackend(clusteropts.Profile, clusteropts.Cluster, clusteropts.Region)
-			if err != nil {
-				return err
-			}
+		RunE: docker.WithAwsContext(dockerCli, func(clusteropts docker.AwsContext, backend *amazon.Backend, args []string) error {
 			if len(args) == 0 {
 				return errors.New("Missing mandatory parameter: NAME")
 			}
@@ -73,11 +69,7 @@ func InspectSecret(dockerCli command.Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "inspect ID",
 		Short: "Displays secret details",
-		RunE: docker.WithAwsContext(dockerCli, func(clusteropts docker.AwsContext, args []string) error {
-			backend, err := amazon.NewBackend(clusteropts.Profile, clusteropts.Cluster, clusteropts.Region)
-			if err != nil {
-				return err
-			}
+		RunE: docker.WithAwsContext(dockerCli, func(clusteropts docker.AwsContext, backend *amazon.Backend, args []string) error {
 			if len(args) == 0 {
 				return errors.New("Missing mandatory parameter: ID")
 			}
@@ -102,11 +94,7 @@ func ListSecrets(dockerCli command.Cli) *cobra.Command {
 		Use:     "list",
 		Aliases: []string{"ls"},
 		Short:   "List secrets stored for the existing account.",
-		RunE: docker.WithAwsContext(dockerCli, func(clusteropts docker.AwsContext, args []string) error {
-			backend, err := amazon.NewBackend(clusteropts.Profile, clusteropts.Cluster, clusteropts.Region)
-			if err != nil {
-				return err
-			}
+		RunE: docker.WithAwsContext(dockerCli, func(clusteropts docker.AwsContext, backend *amazon.Backend, args []string) error {
 			secrets, err := backend.ListSecrets(context.Background())
 			if err != nil {
 				return err
@@ -125,11 +113,7 @@ func DeleteSecret(dockerCli command.Cli) *cobra.Command {
 		Use:     "delete NAME",
 		Aliases: []string{"rm", "remove"},
 		Short:   "Removes a secret.",
-		RunE: docker.WithAwsContext(dockerCli, func(clusteropts docker.AwsContext, args []string) error {
-			backend, err := amazon.NewBackend(clusteropts.Profile, clusteropts.Cluster, clusteropts.Region)
-			if err != nil {
-				return err
-			}
+		RunE: docker.WithAwsContext(dockerCli, func(clusteropts docker.AwsContext, backend *amazon.Backend, args []string) error {
 			if len(args) == 0 {
 				return errors.New("Missing mandatory parameter: [NAME]")
 			}

--- a/pkg/amazon/backend/list.go
+++ b/pkg/amazon/backend/list.go
@@ -4,11 +4,16 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/compose-spec/compose-go/types"
+	"github.com/compose-spec/compose-go/cli"
 	"github.com/docker/ecs-plugin/pkg/compose"
 )
 
-func (b *Backend) Ps(ctx context.Context, project *types.Project) ([]compose.ServiceStatus, error) {
+func (b *Backend) Ps(ctx context.Context, options cli.ProjectOptions) ([]compose.ServiceStatus, error) {
+	project, err := cli.ProjectFromOptions(&options)
+	if err != nil {
+		return nil, err
+	}
+
 	cluster := b.Cluster
 	if cluster == "" {
 		cluster = project.Name

--- a/pkg/amazon/backend/logs.go
+++ b/pkg/amazon/backend/logs.go
@@ -8,11 +8,22 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/compose-spec/compose-go/cli"
+
 	"github.com/docker/ecs-plugin/pkg/console"
 )
 
-func (b *Backend) Logs(ctx context.Context, projectName string) error {
-	err := b.api.GetLogs(ctx, projectName, &logConsumer{
+func (b *Backend) Logs(ctx context.Context, options cli.ProjectOptions) error {
+	name := options.Name
+	if name == "" {
+		project, err := cli.ProjectFromOptions(&options)
+		if err != nil {
+			return err
+		}
+		name = project.Name
+	}
+
+	err := b.api.GetLogs(ctx, name, &logConsumer{
 		colors: map[string]console.ColorFunc{},
 		width:  0,
 	})

--- a/pkg/amazon/sdk/sdk.go
+++ b/pkg/amazon/sdk/sdk.go
@@ -143,7 +143,9 @@ func (s sdk) StackExists(ctx context.Context, name string) (bool, error) {
 		StackName: aws.String(name),
 	})
 	if err != nil {
-		// FIXME doesn't work as expected
+		if strings.HasPrefix(err.Error(), fmt.Sprintf("ValidationError: Stack with id %s does not exist", name)) {
+			return false, nil
+		}
 		return false, nil
 	}
 	return len(stacks.Stacks) > 0, nil

--- a/pkg/compose/api.go
+++ b/pkg/compose/api.go
@@ -13,8 +13,8 @@ type API interface {
 	Down(ctx context.Context, options cli.ProjectOptions) error
 
 	Convert(project *types.Project) (*cloudformation.Template, error)
-	Logs(ctx context.Context, projectName string) error
-	Ps(background context.Context, project *types.Project) ([]ServiceStatus, error)
+	Logs(ctx context.Context, projectName cli.ProjectOptions) error
+	Ps(background context.Context, options cli.ProjectOptions) ([]ServiceStatus, error)
 
 	CreateSecret(ctx context.Context, secret Secret) (string, error)
 	InspectSecret(ctx context.Context, id string) (Secret, error)


### PR DESCRIPTION
**What I did**
Generalized use of `WithAWSContext` so we can get a global error handling
unwrapp AWS API errors to retrieve the error message and avoid sending noise to the end-user.

**Related issue**
Doesn't strictly fix #127 but makes things better :)


**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/86594188-dfdca380-bf96-11ea-9d78-a83ae97274d9.png)
