### PR TITLE
Fix setup command breaks if .aws/config does not exists

### DIFF
--- a/cmd/commands/setup.go
+++ b/cmd/commands/setup.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -101,10 +102,17 @@ func saveCredentials(profile string, accessKeyID string, secretAccessKey string)
 	}
 
 	if err.(awserr.Error).Code() == "SharedCredsLoad" && err.(awserr.Error).Message() == "failed to load shared credentials file" {
-		os.Create(p.Filename)
+		err = os.MkdirAll(filepath.Dir(p.Filename), 0700)
+		if err != nil {
+			return err
+		}
+		_, err = os.Create(p.Filename)
+		if err != nil {
+			return err
+		}
 	}
 
-	credIni, err := ini.Load(p.Filename)
+	credIni, err := ini.LooseLoad(p.Filename)
 	if err != nil {
 		return err
 	}
@@ -122,7 +130,7 @@ func awsProfiles(filename string) (map[string]ini.Section, error) {
 	if filename == "" {
 		filename = defaults.SharedConfigFilename()
 	}
-	credIni, err := ini.Load(filename)
+	credIni, err := ini.LooseLoad(filename)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What I did**
Ignore missing .aws/config file when loading AWS profiles to create ECS context
Enforce .aws/ folder exists when creating initial .aws/credentials file

**Related issue**
closes #132

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/86905695-bcd6fe80-c112-11ea-98e7-48ae94dce8ee.png)
