### PR TITLE
Don't prepent docker.io to image URI. Let the container runtime apply…

### DIFF
--- a/pkg/amazon/backend/cloudformation_test.go
+++ b/pkg/amazon/backend/cloudformation_test.go
@@ -128,7 +128,7 @@ services:
 `)
 	def := template.Resources["TestTaskDefinition"].(*ecs.TaskDefinition)
 	container := def.ContainerDefinitions[0]
-	assert.Equal(t, container.Image, "docker.io/library/image")
+	assert.Equal(t, container.Image, "image")
 	assert.Equal(t, container.Command[0], "command")
 	assert.Equal(t, container.EntryPoint[0], "entrypoint")
 	assert.Equal(t, get(container.Environment, "FOO"), "BAR")

--- a/pkg/amazon/backend/convert.go
+++ b/pkg/amazon/backend/convert.go
@@ -52,7 +52,7 @@ func Convert(project *types.Project, service types.ServiceConfig) (*ecs.TaskDefi
 				FirelensConfiguration: nil,
 				HealthCheck:           toHealthCheck(service.HealthCheck),
 				Hostname:              service.Hostname,
-				Image:                 getImage(service.Image),
+				Image:                 service.Image,
 				Interactive:           false,
 				Links:                 nil,
 				LinuxParameters:       toLinuxParameters(service),
@@ -306,17 +306,6 @@ func toKeyValuePair(environment types.MappingWithEquals) []ecs.TaskDefinition_Ke
 		})
 	}
 	return pairs
-}
-
-func getImage(image string) string {
-	switch f := strings.Split(image, "/"); len(f) {
-	case 1:
-		return "docker.io/library/" + image
-	case 2:
-		return "docker.io/" + image
-	default:
-		return image
-	}
 }
 
 func getRepoCredentials(service types.ServiceConfig) *ecs.TaskDefinition_RepositoryCredentials {

--- a/pkg/amazon/backend/testdata/simple/simple-cloudformation-conversion.golden
+++ b/pkg/amazon/backend/testdata/simple/simple-cloudformation-conversion.golden
@@ -174,7 +174,7 @@
               }
             ],
             "Essential": true,
-            "Image": "docker.io/library/nginx",
+            "Image": "nginx",
             "LinuxParameters": {},
             "LogConfiguration": {
               "LogDriver": "awslogs",

--- a/pkg/amazon/backend/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
+++ b/pkg/amazon/backend/testdata/simple/simple-cloudformation-with-overrides-conversion.golden
@@ -174,7 +174,7 @@
               }
             ],
             "Essential": true,
-            "Image": "docker.io/library/haproxy",
+            "Image": "haproxy",
             "LinuxParameters": {},
             "LogConfiguration": {
               "LogDriver": "awslogs",


### PR DESCRIPTION
**What I did**
Removed attempt to force docker.io as default registry from client (risk for a container runtime to use another default registry for unqualified image URIs is pretty low)

**Related issue**
closes #134

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/86928871-6fb85400-c135-11ea-98f2-262f7db62ead.png)
