### PR TITLE
Use compatibilityChecker to detect missing service image as a blocker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cloudflare/cfssl v1.4.1 // indirect
-	github.com/compose-spec/compose-go v0.0.0-20200707124823-710ff8e60ad9
+	github.com/compose-spec/compose-go v0.0.0-20200709084333-492a50989a5a
 	github.com/containerd/containerd v1.3.2 // indirect
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,8 @@ github.com/compose-spec/compose-go v0.0.0-20200624120600-614475470cd8 h1:sVvKsoX
 github.com/compose-spec/compose-go v0.0.0-20200624120600-614475470cd8/go.mod h1:ih9anT8po+49hrb+1j3ldIJ/YRAaBH52ErlQLTKE2Yo=
 github.com/compose-spec/compose-go v0.0.0-20200707124823-710ff8e60ad9 h1:WkFqc6UpRqxROso9KC+ceaTiXx/VWpeO1x+NV0d4d+o=
 github.com/compose-spec/compose-go v0.0.0-20200707124823-710ff8e60ad9/go.mod h1:ArodJ6gsEB7iWKrbV3fSHZ08LlBvSVB0Oqg04fX86t4=
+github.com/compose-spec/compose-go v0.0.0-20200709084333-492a50989a5a h1:pIiSz5jML7rQ1aupg/KHlTqCxhyXvIgeDMf4kDTzIg8=
+github.com/compose-spec/compose-go v0.0.0-20200709084333-492a50989a5a/go.mod h1:ArodJ6gsEB7iWKrbV3fSHZ08LlBvSVB0Oqg04fX86t4=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.3.0-beta.2.0.20190828155532-0293cbd26c69/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=

--- a/pkg/amazon/backend/cloudformation.go
+++ b/pkg/amazon/backend/cloudformation.go
@@ -31,57 +31,11 @@ const (
 	ParameterLoadBalancerARN = "ParameterLoadBalancerARN"
 )
 
-type FargateCompatibilityChecker struct {
-	compatibility.AllowList
-}
-
-func (c *FargateCompatibilityChecker) CheckPortsPublished(p *types.ServicePortConfig) {
-	if p.Published == 0 {
-		p.Published = p.Target
-	}
-	if p.Published != p.Target {
-		c.Incompatible("published port can't be set to a distinct value than container port")
-	}
-}
-
-func (c *FargateCompatibilityChecker) CheckCapAdd(service *types.ServiceConfig) {
-	add := []string{}
-	for _, cap := range service.CapAdd {
-		switch cap {
-		case "SYS_PTRACE":
-			add = append(add, cap)
-		default:
-			c.Incompatible("ECS doesn't allow to add capability %s", cap)
-		}
-	}
-	service.CapAdd = add
-}
-
 // Convert a compose project into a CloudFormation template
 func (b Backend) Convert(project *types.Project) (*cloudformation.Template, error) {
 	var checker compatibility.Checker = &FargateCompatibilityChecker{
 		compatibility.AllowList{
-			Supported: []string{
-				"services.command",
-				"services.container_name",
-				"services.cap_drop",
-				"services.depends_on",
-				"services.entrypoint",
-				"services.environment",
-				"services.init",
-				"services.healthcheck",
-				"services.healthcheck.interval",
-				"services.healthcheck.start_period",
-				"services.healthcheck.test",
-				"services.healthcheck.timeout",
-				"services.networks",
-				"services.ports",
-				"services.ports.mode",
-				"services.ports.target",
-				"services.ports.protocol",
-				"services.user",
-				"services.working_dir",
-			},
+			Supported: compatibleComposeAttributes,
 		},
 	}
 	compatibility.Check(project, checker)

--- a/pkg/amazon/backend/compatibility.go
+++ b/pkg/amazon/backend/compatibility.go
@@ -1,0 +1,61 @@
+package backend
+
+import (
+	"github.com/compose-spec/compose-go/compatibility"
+	"github.com/compose-spec/compose-go/types"
+)
+
+type FargateCompatibilityChecker struct {
+	compatibility.AllowList
+}
+
+var compatibleComposeAttributes = []string{
+	"services.command",
+	"services.container_name",
+	"services.cap_drop",
+	"services.depends_on",
+	"services.entrypoint",
+	"services.environment",
+	"service.image",
+	"services.init",
+	"services.healthcheck",
+	"services.healthcheck.interval",
+	"services.healthcheck.start_period",
+	"services.healthcheck.test",
+	"services.healthcheck.timeout",
+	"services.networks",
+	"services.ports",
+	"services.ports.mode",
+	"services.ports.target",
+	"services.ports.protocol",
+	"services.user",
+	"services.working_dir",
+}
+
+func (c *FargateCompatibilityChecker) CheckImage(service *types.ServiceConfig) {
+	if service.Image == "" {
+		c.Incompatible("service %s doesn't define a Docker image to run", service.Name)
+	}
+}
+
+func (c *FargateCompatibilityChecker) CheckPortsPublished(p *types.ServicePortConfig) {
+	if p.Published == 0 {
+		p.Published = p.Target
+	}
+	if p.Published != p.Target {
+		c.Incompatible("published port can't be set to a distinct value than container port")
+	}
+}
+
+func (c *FargateCompatibilityChecker) CheckCapAdd(service *types.ServiceConfig) {
+	add := []string{}
+	for _, cap := range service.CapAdd {
+		switch cap {
+		case "SYS_PTRACE":
+			add = append(add, cap)
+		default:
+			c.Incompatible("ECS doesn't allow to add capability %s", cap)
+		}
+	}
+	service.CapAdd = add
+}

--- a/pkg/amazon/backend/convert.go
+++ b/pkg/amazon/backend/convert.go
@@ -17,10 +17,6 @@ import (
 )
 
 func Convert(project *types.Project, service types.ServiceConfig) (*ecs.TaskDefinition, error) {
-	if service.Image == "" {
-		return nil, fmt.Errorf("service %s doesn't define a Docker image to run", service.Name)
-	}
-
 	cpu, mem, err := toLimits(service)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What I did**
Rely on compose-co `CheckImage` to detect missing service.image and report incompatible compose file

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/87018814-105c5180-c1d2-11ea-8ac3-2167296340f2.png)
