### PR TITLE
claim support for deploy.replicas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cloudflare/cfssl v1.4.1 // indirect
-	github.com/compose-spec/compose-go v0.0.0-20200709084333-492a50989a5a
+	github.com/compose-spec/compose-go v0.0.0-20200710075715-6fcc35384ee1
 	github.com/containerd/containerd v1.3.2 // indirect
 	github.com/containerd/continuity v0.0.0-20200413184840-d3ef23f19fbb // indirect
 	github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/compose-spec/compose-go v0.0.0-20200707124823-710ff8e60ad9 h1:WkFqc6U
 github.com/compose-spec/compose-go v0.0.0-20200707124823-710ff8e60ad9/go.mod h1:ArodJ6gsEB7iWKrbV3fSHZ08LlBvSVB0Oqg04fX86t4=
 github.com/compose-spec/compose-go v0.0.0-20200709084333-492a50989a5a h1:pIiSz5jML7rQ1aupg/KHlTqCxhyXvIgeDMf4kDTzIg8=
 github.com/compose-spec/compose-go v0.0.0-20200709084333-492a50989a5a/go.mod h1:ArodJ6gsEB7iWKrbV3fSHZ08LlBvSVB0Oqg04fX86t4=
+github.com/compose-spec/compose-go v0.0.0-20200710075715-6fcc35384ee1 h1:F+YIkKDMHdgZBacawhFY1P9RAIgO+6uv2te6hjsjzF0=
+github.com/compose-spec/compose-go v0.0.0-20200710075715-6fcc35384ee1/go.mod h1:ArodJ6gsEB7iWKrbV3fSHZ08LlBvSVB0Oqg04fX86t4=
 github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqhQ4XNSNC13gXIwDjhOQxjWa/NxkwZXJ1EvqT0ko=
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.3.0-beta.2.0.20190828155532-0293cbd26c69/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=

--- a/pkg/amazon/backend/cloudformation_test.go
+++ b/pkg/amazon/backend/cloudformation_test.go
@@ -93,6 +93,20 @@ services:
 	assert.Check(t, len(lb.SecurityGroups) > 0)
 }
 
+func TestServiceReplicas(t *testing.T) {
+	template := convertYaml(t, `
+version: "3"
+services:
+  test:
+    image: nginx
+    deploy:
+      replicas: 10
+`)
+	s := template.Resources["TestService"].(*ecs.Service)
+	assert.Check(t, s != nil)
+	assert.Check(t, s.DesiredCount == 10)
+}
+
 func TestLoadBalancerTypeNetwork(t *testing.T) {
 	template := convertYaml(t, `
 version: "3"

--- a/pkg/amazon/backend/compatibility.go
+++ b/pkg/amazon/backend/compatibility.go
@@ -14,6 +14,8 @@ var compatibleComposeAttributes = []string{
 	"services.container_name",
 	"services.cap_drop",
 	"services.depends_on",
+	"services.deploy",
+	"services.deploy.replicas",
 	"services.entrypoint",
 	"services.environment",
 	"service.image",


### PR DESCRIPTION
**What I did**
added `service.deploy.replicas` to the list of supported compose attributes

**Related issue**
closes #144

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/87128984-e28a1200-c290-11ea-90e0-0ce806261ca9.png)
