### PR TITLE
Change default context name to 'ecs'.

### DIFF
--- a/cmd/commands/setup.go
+++ b/cmd/commands/setup.go
@@ -66,7 +66,7 @@ func SetupCommand() *cobra.Command {
 			return contextStore.NewContext(opts.name, &opts.context)
 		},
 	}
-	cmd.Flags().StringVarP(&opts.name, "name", "n", "aws", "Context Name")
+	cmd.Flags().StringVarP(&opts.name, "name", "n", "ecs", "Context Name")
 	cmd.Flags().StringVarP(&opts.context.Profile, "profile", "p", "", "AWS Profile")
 	cmd.Flags().StringVarP(&opts.context.Cluster, "cluster", "c", "", "ECS cluster")
 	cmd.Flags().StringVarP(&opts.context.Region, "region", "r", "", "AWS region")


### PR DESCRIPTION
The ACI backend uses 'aci' as the default context name. The ECS backend
uses 'aws'. There may be other AWS or Azure backends so lets name them
for what they are.

Addresses issue #154.



**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or
    "closes #xxxx"
-->

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![tiny](https://3milliondogs.com/blog-assets-two/2015/02/0316.jpg)