### PR TITLE
backend.list: Fix target group parsing

### DIFF
--- a/pkg/amazon/backend/list_test.go
+++ b/pkg/amazon/backend/list_test.go
@@ -1,0 +1,20 @@
+package backend
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestParseTargetGroup(t *testing.T) {
+	pb, err := parseTargetGroup("FrontTCP80TargetGroup")
+	assert.NilError(t, err)
+	assert.Equal(t, "front", pb.ServiceName)
+	assert.Equal(t, "80", pb.Port)
+	assert.Equal(t, "tcp", pb.Protocol)
+}
+
+func TestParseInvalidTargetGroup(t *testing.T) {
+	_, err := parseTargetGroup("Invalid")
+	assert.Error(t, err, "malformed target group ID \"Invalid\"")
+}


### PR DESCRIPTION
**What I did**
* Fixed target group parsing
* Added comments to explain parsing
* Added a test

Note that this fixes the current parsing logic. The other approach would be to use the AWS API to resolve the target group information instead.

**Related issue**
Fixes #178.