### PR TITLE
backend.list: Use the AWS APIs to resolve the target group information

### DIFF
--- a/cmd/commands/compose.go
+++ b/cmd/commands/compose.go
@@ -91,7 +91,7 @@ func PsCommand(dockerCli command.Cli, options *cli.ProjectOptions) *cobra.Comman
 			}
 			printSection(os.Stdout, len(status), func(w io.Writer) {
 				for _, service := range status {
-					fmt.Fprintf(w, "%s\t%s\t%d/%d\t%s\n", service.ID, service.Name, service.Replicas, service.Desired, strings.Join(service.Ports, " "))
+					fmt.Fprintf(w, "%s\t%s\t%d/%d\t%s\n", service.ID, service.Name, service.Replicas, service.Desired, strings.Join(service.Ports, ", "))
 				}
 			}, "ID", "NAME", "REPLICAS", "PORTS")
 			return nil

--- a/pkg/compose/types.go
+++ b/pkg/compose/types.go
@@ -9,12 +9,25 @@ type StackResource struct {
 	Status    string
 }
 
+type PortMapping struct {
+	Source int
+	Target int
+}
+
+type LoadBalancer struct {
+	URL           string
+	TargetPort    int
+	PublishedPort int
+	Protocol      string
+}
+
 type ServiceStatus struct {
-	ID       string
-	Name     string
-	Replicas int
-	Desired  int
-	Ports    []string
+	ID            string
+	Name          string
+	Replicas      int
+	Desired       int
+	Ports         []string
+	LoadBalancers []LoadBalancer
 }
 
 const (


### PR DESCRIPTION
Fixes #178.
 - use AWS APIs to retrieve load balancer and target group information for displaying on compose ps. 

```
$ cat docker-compose.yml
version: "3"
x-aws-vpc: "vpc-57abbc3e"
services:
  hello:
    image: ancaiordache/hello_docker
    ports:
      - 8080:8080


docker-ecs ecs compose ps
ID                                NAME                REPLICAS            PORTS
hello-HelloService-OAPR4XZ6EL4V   hello               1/1                 HelloLoadBalancer-6f4d99520b611744.elb.eu-west-3.amazonaws.com:8080->8080/tcp
```

```
$ cat docker-compose.yml
version: "3"
x-aws-vpc: "vpc-57abbc3e"
services:
  hello:
    image: ancaiordache/hello_docker


$ docker ecs compose ps
ID                                 NAME                REPLICAS            PORTS
hello-HelloService-1CEW46I9QIEZO   hello               1/1                 


```




Fixes #178.