### PR TITLE
Enable custom VPC support and relax subnet filter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:experimental
 ARG GO_VERSION=1.14.4-alpine
-ARG ALPINE_PKG_DOCKER_VERSION=19.03.11-r0
+ARG ALPINE_PKG_DOCKER_VERSION=19.03.12-r0
 ARG GOLANGCI_LINT_VERSION=v1.27.0-alpine
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION} AS base

--- a/pkg/amazon/backend/up.go
+++ b/pkg/amazon/backend/up.go
@@ -40,6 +40,9 @@ func (b *Backend) Up(ctx context.Context, options cli.ProjectOptions) error {
 	if err != nil {
 		return err
 	}
+	if len(subNets) < 2 {
+		return fmt.Errorf("VPC %s should have at least 2 associated subnets in different availability zones", vpc)
+	}
 
 	lb, err := b.GetLoadBalancer(ctx, project)
 	if err != nil {
@@ -95,6 +98,7 @@ func (b Backend) GetVPC(ctx context.Context, project *types.Project) (string, er
 		if !ok {
 			return "", fmt.Errorf("VPC does not exist: %s", vpc)
 		}
+		return vpcID, nil
 	}
 	defaultVPC, err := b.api.GetDefaultVPC(ctx)
 	if err != nil {

--- a/pkg/amazon/sdk/sdk.go
+++ b/pkg/amazon/sdk/sdk.go
@@ -125,10 +125,6 @@ func (s sdk) GetSubNets(ctx context.Context, vpcID string) ([]string, error) {
 				Name:   aws.String("vpc-id"),
 				Values: []*string{aws.String(vpcID)},
 			},
-			{
-				Name:   aws.String("default-for-az"),
-				Values: []*string{aws.String("true")},
-			},
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes the custom VPC support (missing return statement after validation of the VPC id) and removed subnet filter enforcing the VPC to be set as a default for the availability zone.

To test this, I set up a custom VPC and the following (Amazon VPC service):
 - Subnets: the vpc must have at least 2 subnets associated in 2 different availability zones.
- Internet gateway:  the vpc must have attached an internet gateway (`igw-006eb82f5fb780b34`)
- Route Table:  add a route to send the traffic to the internet gateway otherwise we can't connect to external container registry (docker hub) to pull images. Setup described here: https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html

```
Route Table: rtb-0c4844de99982be2e

Destination | Target     | Status | Propagated
...
0.0.0.0/0   | igw-006eb82f5fb780b34 | active | No

```


Closes #184 

