### PR TITLE
Remove `compose up` timeout

### DIFF
--- a/pkg/amazon/sdk/sdk.go
+++ b/pkg/amazon/sdk/sdk.go
@@ -181,7 +181,7 @@ func (s sdk) CreateStack(ctx context.Context, name string, template *cf.Template
 		StackName:        aws.String(name),
 		TemplateBody:     aws.String(string(json)),
 		Parameters:       param,
-		TimeoutInMinutes: aws.Int64(15),
+		TimeoutInMinutes: nil,
 		Capabilities: []*string{
 			aws.String(cloudformation.CapabilityCapabilityIam),
 		},

--- a/pkg/compose/types.go
+++ b/pkg/compose/types.go
@@ -9,11 +9,6 @@ type StackResource struct {
 	Status    string
 }
 
-type PortMapping struct {
-	Source int
-	Target int
-}
-
 type LoadBalancer struct {
 	URL           string
 	TargetPort    int


### PR DESCRIPTION
Remove timeout from compose up and run instead a `compose down` on Ctrl^C.

closes https://github.com/docker/ecs-plugin/issues/177