### PR TITLE
add shared config state to session

### DIFF
--- a/pkg/amazon/backend/backend.go
+++ b/pkg/amazon/backend/backend.go
@@ -8,7 +8,8 @@ import (
 
 func NewBackend(profile string, region string) (*Backend, error) {
 	sess, err := session.NewSessionWithOptions(session.Options{
-		Profile: profile,
+		Profile:           profile,
+		SharedConfigState: session.SharedConfigEnable,
 		Config: aws.Config{
 			Region: aws.String(region),
 		},


### PR DESCRIPTION
**What I did**

By adding this flag to the session, we force the AWS Go SDK to read the ~/.aws/config file. By default, the Go SDK doesn't read this file which is often not what we or customers expect. Many customers store their assume role based prfoiles in the .aws/config file rather than the .aws/credentials file.  

This new behavior is what the AWS CLI does, by default - but that's because this parameter is enabled by default in the python SDK.

[Here's](https://gist.github.com/kohidave/8ca36e4207d81d3b03eed49c245bffac) a little example of the difference and how it'll fail. 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**

![](https://upload.wikimedia.org/wikipedia/commons/3/32/Dalmatian_puppy_01.jpg)

This cute doggy took a nap after doing hard work. I will take a nap after this PR, as well. 