### PR TITLE
Interpolate variables on up command

### DIFF
--- a/cmd/commands/compose.go
+++ b/cmd/commands/compose.go
@@ -73,7 +73,7 @@ func UpCommand(dockerCli command.Cli, options *cli.ProjectOptions) *cobra.Comman
 	cmd := &cobra.Command{
 		Use: "up",
 		RunE: WithAwsContext(dockerCli, func(clusteropts docker.AwsContext, backend *amazon.Backend, args []string) error {
-			return backend.Up(context.Background(), *options)
+			return backend.Up(context.Background(), options.WithOsEnv())
 		}),
 	}
 	cmd.Flags().StringVar(&opts.loadBalancerArn, "load-balancer", "", "")


### PR DESCRIPTION
Signed-off-by: Ryan Malesic <ryanmalesic@icloud.com>

<!-- Make sure all your commits include a signature generated with `git commit -s`
-->
**What I did**
Interpolate variables on up command.

I am not certain if there was a specific reason not to interpolate variables on the up command, but this change makes it work.

**Related issue**
<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or
    "closes #xxxx"
-->
Fixes #202 

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![1488330286332](https://user-images.githubusercontent.com/44401389/89114157-4f836880-d447-11ea-8ffc-4863af36671a.png)