### PR TITLE
Claim support for healthcheck.retries

### DIFF
--- a/pkg/amazon/backend/compatibility.go
+++ b/pkg/amazon/backend/compatibility.go
@@ -28,6 +28,7 @@ var compatibleComposeAttributes = []string{
 	"services.init",
 	"services.healthcheck",
 	"services.healthcheck.interval",
+	"services.healthcheck.retries",
 	"services.healthcheck.start_period",
 	"services.healthcheck.test",
 	"services.healthcheck.timeout",


### PR DESCRIPTION
**What I did**
Don't reject services.healthcheck.retries as the code to support this attribute is [already present](https://github.com/docker/ecs-plugin/blob/master/pkg/amazon/backend/convert.go#L278-L285)

**Related issue**
closes #221

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/89756734-a8a46980-dae3-11ea-94d6-d47948040ed7.png)
