### PR TITLE
Don't set targetGroup a name to avoid conflicts

### DIFF
--- a/pkg/amazon/backend/cloudformation.go
+++ b/pkg/amazon/backend/cloudformation.go
@@ -307,7 +307,6 @@ func createTargetGroup(project *types.Project, service types.ServiceConfig, port
 		port.Published,
 	)
 	template.Resources[targetGroupName] = &elasticloadbalancingv2.TargetGroup{
-		Name:     targetGroupName,
 		Port:     int(port.Target),
 		Protocol: protocol,
 		Tags: []tags.Tag{


### PR DESCRIPTION
**What I did**
Remove Name we set to TargetGroup, which could conflict with another deployment of the same app, or another app with same service name and port.
Name is actually unnecessary as we use CloudFormation Refs to link components together.

**Related issue**
closes #213

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/89756962-36805480-dae4-11ea-804e-8b69c8438f90.png)
