### PR TITLE
Allow user to customize Roles / ManagedPolicy

### DIFF
--- a/pkg/amazon/backend/iam.go
+++ b/pkg/amazon/backend/iam.go
@@ -22,7 +22,7 @@ var assumeRolePolicyDocument = PolicyDocument{
 	},
 }
 
-// could alternatively depend on https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/master/pkg/cloud/services/iam/types.go#L52
+// could alternatively depend on https://github.com/kubernetes-sigs/cluster-api-provider-aws/blob/master/cmd/clusterawsadm/api/iam/v1alpha1/types.go
 type PolicyDocument struct {
 	Version   string            `json:",omitempty"`
 	Statement []PolicyStatement `json:",omitempty"`

--- a/pkg/compose/x.go
+++ b/pkg/compose/x.go
@@ -10,4 +10,6 @@ const (
 	ExtensionMinPercent      = "x-aws-min_percent"
 	ExtensionMaxPercent      = "x-aws-max_percent"
 	ExtensionRetention       = "x-aws-logs_retention"
+	ExtensionRole            = "x-aws-role"
+	ExtensionManagedPolicies = "x-aws-policies"
 )


### PR DESCRIPTION
**What I did**
Add support for user to define additional Managed policies, or a full IAM Role if they need to

Sample usage:
```yaml
services:
  backend:
    image: ndeloof/backend
    port:
      - "80:80"
    x-aws-policies: 
      - "arn:aws:iam::aws:policy/AmazonS3FullAccess"
```

Full IAM Role definition:
Sample usage:
```yaml
services:
  backend:
    image: ndeloof/backend
    port:
      - "80:80"
    x-aws-role: 
      Version: "2012-10-17"
      Statement:
        - Effect: "Allow"
          Action: 
             -   "ecr:GetAuthorizationToken"
             -   "ecr:BatchCheckLayerAvailability"
             -   "ecr:GetDownloadUrlForLayer"
             -   "ecr:BatchGetImage"
             -   "logs:CreateLogStream"
             -   "logs:PutLogEvents"
          Resource: "*"
        }
    ]
}      
```

**Related issue**
closes #211

**(not mandatory) A picture of a cute animal, if possible in relation with what you did**
![image](https://user-images.githubusercontent.com/132757/90141954-11a60e80-dd7c-11ea-98a0-8270252c4bb5.png)
