### PR TITLE
Init progress writer in WaitStackCompletion

### DIFF
--- a/cmd/commands/compose.go
+++ b/cmd/commands/compose.go
@@ -82,7 +82,6 @@ func UpCommand(dockerCli command.Cli, options *composeOptions) *cobra.Command {
 			}
 
 			return progress.Run(context.Background(), func(ctx context.Context) error {
-				backend.SetWriter(ctx)
 				return backend.Up(ctx, opts)
 			})
 		}),
@@ -130,7 +129,6 @@ func DownCommand(dockerCli command.Cli, options *composeOptions) *cobra.Command 
 				return err
 			}
 			return progress.Run(context.Background(), func(ctx context.Context) error {
-				backend.SetWriter(ctx)
 				return backend.Down(ctx, opts)
 			})
 		}),

--- a/pkg/amazon/backend/backend.go
+++ b/pkg/amazon/backend/backend.go
@@ -1,12 +1,9 @@
 package backend
 
 import (
-	"context"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/docker/ecs-plugin/pkg/amazon/sdk"
-	"github.com/docker/ecs-plugin/pkg/progress"
 )
 
 func NewBackend(profile string, region string) (*Backend, error) {
@@ -30,9 +27,4 @@ func NewBackend(profile string, region string) (*Backend, error) {
 type Backend struct {
 	Region string
 	api    sdk.API
-	writer progress.Writer
-}
-
-func (b *Backend) SetWriter(context context.Context) {
-	b.writer = progress.ContextWriter(context)
 }

--- a/pkg/amazon/backend/wait.go
+++ b/pkg/amazon/backend/wait.go
@@ -14,7 +14,8 @@ import (
 
 func (b *Backend) WaitStackCompletion(ctx context.Context, name string, operation int) error {
 	knownEvents := map[string]struct{}{}
-
+	// progress writer
+	w := progress.ContextWriter(ctx)
 	// Get the unique Stack ID so we can collect events without getting some from previous deployments with same name
 	stackID, err := b.api.GetStackID(ctx, name)
 	if err != nil {
@@ -80,7 +81,7 @@ func (b *Backend) WaitStackCompletion(ctx context.Context, name string, operatio
 					}
 				}
 			}
-			b.writer.Event(progress.Event{
+			w.Event(progress.Event{
 				ID:         resource,
 				Status:     progressStatus,
 				StatusText: status,


### PR DESCRIPTION
Remove the progress SetWriter method. Initialize it before use from context.

```
$ docker ecs compose up
[+] Running 12/12
 ⠿ hello                       CREATE_COMPLETE                                                                                          221.0s
 ⠿ HelloTCP8080TargetGroup     CREATE_COMPLETE                                                                                            0.0s
 ⠿ HelloLoadBalancer           CREATE_COMPLETE                                                                                          152.0s
 ⠿ LogGroup                    CREATE_COMPLETE                                                                                            1.0s
 ⠿ HelloDefaultNetwork         CREATE_COMPLETE                                                                                            6.0s
 ⠿ CloudMap                    CREATE_COMPLETE                                                                                           46.0s
 ⠿ HelloTaskExecutionRole      CREATE_COMPLETE                                                                                           16.0s
 ⠿ HelloDefaultNetworkIngress  CREATE_COMPLETE                                                                                            1.0s
 ⠿ HelloTaskDefinition         CREATE_COMPLETE                                                                                            2.0s
 ⠿ HelloServiceDiscoveryEntry  CREATE_COMPLETE                                                                                            1.0s
 ⠿ HelloTCP8080Listener        CREATE_COMPLETE                                                                                            1.0s
 ⠿ HelloService                CREATE_COMPLETE                                                                                           62.0s

$ docker ecs compose ps
ID                                 NAME                REPLICAS            PORTS
hello-HelloService-1KQ0JF63P6884   hello               1/1                 HelloLoadBalancer-b75f64ad32a8138c.elb.eu-west-3.amazonaws.com:8080->8080/tcp
 
$ docker ecs compose down
[+] Running 1/12
 ⠦ hello                       DELETE_IN_PROGRESS                                                                                        94.3s
 ⠦ HelloTCP8080TargetGroup     CREATE_COMPLETE                                                                                           94.3s
 ⠦ HelloLoadBalancer           CREATE_COMPLETE                                                                                           94.3s
 ⠦ LogGroup                    CREATE_COMPLETE                                                                                           94.3s
 ⠦ HelloDefaultNetwork         CREATE_COMPLETE                                                                                           94.3s
 ⠦ CloudMap                    CREATE_COMPLETE                                                                                           94.3s
 ⠦ HelloTaskExecutionRole      CREATE_COMPLETE                                                                                           94.3s
 ⠿ HelloDefaultNetworkIngress  DELETE_COMPLETE                                                                                            2.0s
 ⠦ HelloTaskDefinition         CREATE_COMPLETE                                                                                           94.3s
 ⠦ HelloServiceDiscoveryEntry  CREATE_COMPLETE                                                                                           94.3s
 ⠦ HelloTCP8080Listener        CREATE_COMPLETE                                                                                           94.3s
 ⠦ HelloService                DELETE_IN_PROGRESS 
```