### PR TITLE
adds delete-ecr makefile target

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -8,6 +8,16 @@ all: build-image
 create-ecr:
 	aws ecr create-repository --repository-name ${FRONTEND_IMG}
 
+delete-ecr:
+	aws ecr batch-delete-image \
+		--registry-id $(REGISTRY_ID) \
+		--repository-name ${FRONTEND_IMG} \
+		--image-ids imageTag=$(shell aws ecr list-images \
+										--repository-name $(FRONTEND_IMG) \
+										--query 'imageIds[].imageTag' \
+										--output text)
+	aws ecr delete-repository --repository-name ${FRONTEND_IMG}
+
 build-image:
 	docker build -t $(REGISTRY_ID).$(DOCKER_PUSH_REPOSITORY)/$(FRONTEND_IMG) ./app
 	docker build -t $(FRONTEND_IMG) ./app


### PR DESCRIPTION
**What I did**

Added a Makefile target that cleans up resources created by the existing `create-ecr` target.

- deletes the existing image from the created repository
- deletes the repository

**Related issue**

we use `create-ecr` to make a repo. we would do well to clean up that repo when done in the likely event a person following this example is using company resources.

**Added a Makefile target**
![image](https://user-images.githubusercontent.com/7256942/92957049-c46d9900-f41c-11ea-8ca9-7f45ea39c005.png)

Signed-off-by: Camilo Santana <camilosantana@gmail.com>
