### PR TITLE
makefile - variable - replaces us-west-2 w/ current profile’s AWS_REGION

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -1,7 +1,8 @@
+AWS_REGION := $(shell aws ec2 describe-availability-zones --output text --query 'AvailabilityZones[0].[RegionName]')
 REPO_NAMESPACE ?= ${USER}
 FRONTEND_IMG = ${REPO_NAMESPACE}/timestamper
 REGISTRY_ID ?= PUT_ECR_REGISTRY_ID_HERE
-DOCKER_PUSH_REPOSITORY=dkr.ecr.us-west-2.amazonaws.com
+DOCKER_PUSH_REPOSITORY=dkr.ecr.$(AWS_REGION).amazonaws.com
 
 all: build-image
 
@@ -13,7 +14,7 @@ build-image:
 	docker build -t $(FRONTEND_IMG) ./app
 
 push-image-ecr:
-	aws ecr get-login-password --region us-west-2 | docker login -u AWS --password-stdin $(REGISTRY_ID).$(DOCKER_PUSH_REPOSITORY)
+	aws ecr get-login-password --region $(AWS_REGION) | docker login -u AWS --password-stdin $(REGISTRY_ID).$(DOCKER_PUSH_REPOSITORY)
 	docker push $(REGISTRY_ID).$(DOCKER_PUSH_REPOSITORY)/$(FRONTEND_IMG)
 
 push-image-hub:


### PR DESCRIPTION
taken from https://stackoverflow.com/questions/31331788/using-aws-cli-what-is-best-way-to-determine-the-current-region/63496689#63496689

**What I did**

replaced `us-west-2` strings w/ current profile’s region via aws-cli per this [stack overflow solution]'s proposal to best determine said region..

**Related issue**

This way developers don't have to edit the string in `makefile`

![image](https://user-images.githubusercontent.com/7256942/92958331-e536ee00-f41e-11ea-84dc-5a06573d2d38.png)

Signed-off-by: Camilo Santana <camilosantana@gmail.com>

[stack overflow solution]: https://stackoverflow.com/questions/31331788/using-aws-cli-what-is-best-way-to-determine-the-current-region/63496689#63496689